### PR TITLE
PRACMIG-628: Calculate average cutover duration

### DIFF
--- a/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
+++ b/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
@@ -4,6 +4,6 @@
   "migration_occurrences_bucket_name": "prm-pracmig-migration-occurrences-dev",
   "metrics_bucket_name": "prm-pracmig-metrics-dev",
   "metrics_calculator_deployment_bucket_name": "prm-pracmig-metrics-calculator-deployments-dev",
-  "metrics_calculator_code_key": "68a19d751ff63617a2202b7b905d07b9",
+  "metrics_calculator_code_key": "f3093c8d888cd48ab74909c415d0efc2",
   "metrics_calculator_handler_name": "app.calculate_dashboard_metrics_from_telemetry"
 }

--- a/metrics-calculator/tests/integration/test_app.py
+++ b/metrics-calculator/tests/integration/test_app.py
@@ -66,16 +66,18 @@ def test_calculate_dashboard_metrics_from_telemetry(
     migrations_obj = metrics_bucket.Object("migrations.json").get()
     migrations_body = migrations_obj['Body'].read().decode('utf-8')
 
-    assert json.loads(migrations_body) == {"migrations": [{
-        "cutover_startdate": "2021-12-02T15:42:00+00:00",
-        "cutover_enddate": "2021-12-05T15:42:00+00:00",
-        "cutover_duration": 3,
-        "ccg_name": ccg,
-        "practice_name": practice,
-        "source_system": "SystmOne",
-        "target_system": "EMIS Web",
-        "ods_code": ods_code
-    }]}
+    assert json.loads(migrations_body) == {
+        "mean_cutover_duration": "3.0",
+        "migrations": [{
+            "cutover_startdate": "2021-12-02T15:42:00+00:00",
+            "cutover_enddate": "2021-12-05T15:42:00+00:00",
+            "cutover_duration": 3,
+            "ccg_name": ccg,
+            "practice_name": practice,
+            "source_system": "SystmOne",
+            "target_system": "EMIS Web",
+            "ods_code": ods_code
+        }]}
 
 
 def create_occurrences_data(occurrences_bucket_name, s3, ods_code, ccg, practice):


### PR DESCRIPTION
Update the metrics calculator lambda to calculate the average cutover duration.

NOTE: This does not update the dashboard to actually display this data yet.