### PR TITLE
PRACMIG-693: Configurable Splunk URL

### DIFF
--- a/metrics-calculator/.chalice/config.json
+++ b/metrics-calculator/.chalice/config.json
@@ -11,6 +11,14 @@
             "TELEMETRY_BUCKET_NAME": "prm-pracmig-telemetry-dev",
             "METRICS_BUCKET_NAME": "prm-pracmig-metrics-dev"
           }
+        },
+        "export_splunk_data": {
+          "environment_variables": {
+            "OCCURRENCES_BUCKET_NAME": "prm-pracmig-migration-occurrences-dev",
+            "ASID_LOOKUP_BUCKET_NAME": "prm-pracmig-asid-lookup-dev",
+            "TELEMETRY_BUCKET_NAME": "prm-pracmig-telemetry-dev",
+            "SPLUNK_BASE_URL": "https://dev.splunk.url"
+          }
         }
       }
     }

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -71,6 +71,7 @@ def export_splunk_data(event, context):
     occurrences_bucket_name = os.environ['OCCURRENCES_BUCKET_NAME']
     asid_lookup_bucket_name = os.environ['ASID_LOOKUP_BUCKET_NAME']
     telemetry_bucket_name = os.environ['TELEMETRY_BUCKET_NAME']
+    splunk_base_url = os.environ['SPLUNK_BASE_URL']
 
     s3 = get_s3_resource()
     known_migrations = get_migration_occurrences(
@@ -90,7 +91,7 @@ def export_splunk_data(event, context):
             migration["date"])
 
         baseline_threshold = get_baseline_threshold_from_splunk_data(
-            old_asid, baseline_date_range)
+            splunk_base_url, old_asid, baseline_date_range)
 
         pre_cutover_telemetry = get_telemetry_from_splunk(
             old_asid,
@@ -105,8 +106,10 @@ def export_splunk_data(event, context):
 
         pre_cutover_telemetry_filename = f"{old_asid}-telemetry.csv.gz"
         post_cutover_telemetry_filename = f"{new_asid}-telemetry.csv.gz"
-        upload_telemetry(s3, telemetry_bucket_name, pre_cutover_telemetry, pre_cutover_telemetry_filename)
-        upload_telemetry(s3, telemetry_bucket_name, post_cutover_telemetry, post_cutover_telemetry_filename)
+        upload_telemetry(
+            s3, telemetry_bucket_name, pre_cutover_telemetry, pre_cutover_telemetry_filename)
+        upload_telemetry(
+            s3, telemetry_bucket_name, post_cutover_telemetry, post_cutover_telemetry_filename)
 
     return "ok"
 

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -94,11 +94,13 @@ def export_splunk_data(event, context):
             splunk_base_url, old_asid, baseline_date_range)
 
         pre_cutover_telemetry = get_telemetry_from_splunk(
+            splunk_base_url,
             old_asid,
             baseline_threshold,
             pre_cutover_date_range
         )
         post_cutover_telemetry = get_telemetry_from_splunk(
+            splunk_base_url,
             new_asid,
             baseline_threshold,
             post_cutover_date_range

--- a/metrics-calculator/chalicelib/get_data_from_splunk.py
+++ b/metrics-calculator/chalicelib/get_data_from_splunk.py
@@ -18,7 +18,7 @@ def get_baseline_threshold_from_splunk_data(
     return threshold
 
 
-def get_telemetry_from_splunk(asid, date_range, baseline_threshold):
+def get_telemetry_from_splunk(splunk_base_url, asid, date_range, baseline_threshold):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | timechart span=1d count
 | fillnull
@@ -27,7 +27,7 @@ def get_telemetry_from_splunk(asid, date_range, baseline_threshold):
 | eval avgmin2std={baseline_threshold}
 | fields - day_of_week"""
     response = make_splunk_request(
-        "/?activationRegion=eu-west-2", date_range, search_text)
+        f"{splunk_base_url}/search/jobs/export", date_range, search_text)
     return response
 
 

--- a/metrics-calculator/chalicelib/get_data_from_splunk.py
+++ b/metrics-calculator/chalicelib/get_data_from_splunk.py
@@ -11,9 +11,9 @@ class SplunkParseError(Exception):
 
 
 def get_baseline_threshold_from_splunk_data(
-        splunk_url, asid, baseline_date_range):
+        splunk_base_url, asid, baseline_date_range):
     response = make_request_for_baseline_telemetry(
-        splunk_url, asid, baseline_date_range)
+        splunk_base_url, asid, baseline_date_range)
     threshold = parse_threshold_from_splunk_response(response)
     return threshold
 
@@ -31,7 +31,7 @@ def get_telemetry_from_splunk(asid, date_range, baseline_threshold):
     return response
 
 
-def make_request_for_baseline_telemetry(splunk_url, asid, baseline_date_range):
+def make_request_for_baseline_telemetry(splunk_base_url, asid, baseline_date_range):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | bucket span=1d _time
 | eval day_of_week = strftime(_time,"%A")
@@ -42,7 +42,7 @@ def make_request_for_baseline_telemetry(splunk_url, asid, baseline_date_range):
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     response = make_splunk_request(
-        splunk_url, baseline_date_range, search_text)
+        f"{splunk_base_url}/search/jobs/export", baseline_date_range, search_text)
     return response
 
 

--- a/metrics-calculator/tests/unit/test_app.py
+++ b/metrics-calculator/tests/unit/test_app.py
@@ -440,6 +440,7 @@ def test_export_splunk_data_queries_splunk_data_using_baseline_threshold(
         calculate_pre_cutover_date_range_mock,
         calculate_post_cutover_date_range_mock,
         lookup_asids_mock,
+        exporter_lambda_env_vars,
         get_baseline_threshold_from_splunk_data_mock,
         get_telemetry_from_splunk_mock):
     migration_occurrence = {
@@ -461,10 +462,12 @@ def test_export_splunk_data_queries_splunk_data_using_baseline_threshold(
     export_splunk_data({}, {})
 
     get_telemetry_from_splunk_mock.assert_any_call(
+        exporter_lambda_env_vars["SPLUNK_BASE_URL"],
         old_asid,
         baseline_threshold,
         calculate_pre_cutover_date_range_mock.return_value)
     get_telemetry_from_splunk_mock.assert_any_call(
+        exporter_lambda_env_vars["SPLUNK_BASE_URL"],
         new_asid,
         baseline_threshold,
         calculate_post_cutover_date_range_mock.return_value)

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -29,7 +29,6 @@ def splunk_request(monkeypatch):
 
 
 def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_telemetry(splunk_response):
-    asid = "12345"
     baseline_date_range = {"start_date": date(
         2021, 4, 6), "end_date": date(2021, 6, 28)}
 
@@ -37,27 +36,25 @@ def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
     baseline_threshold = get_baseline_threshold_from_splunk_data(
-        "", asid, baseline_date_range)
+        "", "12345", baseline_date_range)
 
     assert baseline_threshold == "4537.33933970307"
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_no_results(splunk_response):
-    asid = "not-a-valid-asid"
     baseline_date_range = {
         "start_date": date(2021, 4, 6),
         "end_date": date(2021, 6, 28)
     }
-
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",0,""0""", status=200)
 
     with pytest.raises(ValueError, match="Threshold is not a positive value"):
-        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data(
+            "", "12345", baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(splunk_response):
-    asid = "12345"
     baseline_date_range = {
         "start_date": date(2021, 4, 6),
         "end_date": date(2021, 6, 28)
@@ -66,11 +63,11 @@ def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(s
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data(
+            "", "12345", baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_response):
-    asid = "12345"
     baseline_date_range = {
         "start_date": date(2021, 4, 6),
         "end_date": date(2021, 6, 28)
@@ -80,7 +77,8 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
         read=lambda: "this-is-not-a-byte-string", status=200)
 
     with pytest.raises(SplunkParseError):
-        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data(
+            "", "12345", baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
@@ -113,7 +111,6 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
-    asid = "12345"
     date_range = {
         "start_date": date(2021, 6, 29),
         "end_date": date(2021, 7, 19)}
@@ -122,13 +119,12 @@ def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
-    telemetry = get_telemetry_from_splunk("", asid, date_range, threshold)
+    telemetry = get_telemetry_from_splunk("", "12345", date_range, threshold)
 
     assert telemetry == splunk_response.return_value
 
 
 def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response):
-    asid = "12345"
     date_range = {
         "start_date": date(2021, 6, 29),
         "end_date": date(2021, 7, 19)
@@ -138,7 +134,7 @@ def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_telemetry_from_splunk("", asid, date_range, threshold)
+        get_telemetry_from_splunk("", "12345", date_range, threshold)
 
 
 def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -36,7 +36,7 @@ def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
     baseline_threshold = get_baseline_threshold_from_splunk_data(
-        "", "12345", baseline_date_range)
+        "", anAsid(), baseline_date_range)
 
     assert baseline_threshold == "4537.33933970307"
 
@@ -51,7 +51,7 @@ def test_get_baseline_threshold_from_splunk_data_handles_no_results(splunk_respo
 
     with pytest.raises(ValueError, match="Threshold is not a positive value"):
         get_baseline_threshold_from_splunk_data(
-            "", "12345", baseline_date_range)
+            "", anAsid(), baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(splunk_response):
@@ -64,7 +64,7 @@ def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(s
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
         get_baseline_threshold_from_splunk_data(
-            "", "12345", baseline_date_range)
+            "", anAsid(), baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_response):
@@ -78,11 +78,11 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
 
     with pytest.raises(SplunkParseError):
         get_baseline_threshold_from_splunk_data(
-            "", "12345", baseline_date_range)
+            "", anAsid(), baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
-    asid = "12345"
+    asid = anAsid()
     baseline_date_range = {
         "start_date": date(2021, 4, 6),
         "end_date": date(2021, 6, 28)
@@ -119,7 +119,7 @@ def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
-    telemetry = get_telemetry_from_splunk("", "12345", date_range, threshold)
+    telemetry = get_telemetry_from_splunk("", anAsid(), date_range, threshold)
 
     assert telemetry == splunk_response.return_value
 
@@ -134,11 +134,11 @@ def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_telemetry_from_splunk("", "12345", date_range, threshold)
+        get_telemetry_from_splunk("", anAsid(), date_range, threshold)
 
 
 def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
-    asid = "12345"
+    asid = anAsid()
     date_range = {
         "start_date": date(2021, 6, 29),
         "end_date": date(2021, 7, 19)
@@ -162,3 +162,7 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
     }
     splunk_request.assert_called_once_with(
         "POST", f"{splunk_base_url}/search/jobs/export", expected_request_body)
+
+
+def anAsid():
+    return "12345"

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -29,64 +29,42 @@ def splunk_request(monkeypatch):
 
 
 def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_telemetry(splunk_response):
-    baseline_date_range = {"start_date": date(
-        2021, 4, 6), "end_date": date(2021, 6, 28)}
-
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
     baseline_threshold = get_baseline_threshold_from_splunk_data(
-        "", anAsid(), baseline_date_range)
+        "", anAsid(), aDateRange())
 
     assert baseline_threshold == "4537.33933970307"
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_no_results(splunk_response):
-    baseline_date_range = {
-        "start_date": date(2021, 4, 6),
-        "end_date": date(2021, 6, 28)
-    }
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",0,""0""", status=200)
 
     with pytest.raises(ValueError, match="Threshold is not a positive value"):
-        get_baseline_threshold_from_splunk_data(
-            "", anAsid(), baseline_date_range)
+        get_baseline_threshold_from_splunk_data("", anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(splunk_response):
-    baseline_date_range = {
-        "start_date": date(2021, 4, 6),
-        "end_date": date(2021, 6, 28)
-    }
-
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_baseline_threshold_from_splunk_data(
-            "", anAsid(), baseline_date_range)
+        get_baseline_threshold_from_splunk_data("", anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_response):
-    baseline_date_range = {
-        "start_date": date(2021, 4, 6),
-        "end_date": date(2021, 6, 28)
-    }
-
     splunk_response.return_value = Mock(
         read=lambda: "this-is-not-a-byte-string", status=200)
 
     with pytest.raises(SplunkParseError):
         get_baseline_threshold_from_splunk_data(
-            "", anAsid(), baseline_date_range)
+            "", anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
     asid = anAsid()
-    baseline_date_range = {
-        "start_date": date(2021, 4, 6),
-        "end_date": date(2021, 6, 28)
-    }
+    baseline_date_range = aDateRange()
     splunk_base_url = "https://test-splunk"
 
     get_baseline_threshold_from_splunk_data(
@@ -111,38 +89,29 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
-    date_range = {
-        "start_date": date(2021, 6, 29),
-        "end_date": date(2021, 7, 19)}
     threshold = "4537.33933970307"
 
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
-    telemetry = get_telemetry_from_splunk("", anAsid(), date_range, threshold)
+    telemetry = get_telemetry_from_splunk(
+        "", anAsid(), aDateRange(), threshold)
 
     assert telemetry == splunk_response.return_value
 
 
 def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response):
-    date_range = {
-        "start_date": date(2021, 6, 29),
-        "end_date": date(2021, 7, 19)
-    }
     threshold = "4537.33933970307"
 
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_telemetry_from_splunk("", anAsid(), date_range, threshold)
+        get_telemetry_from_splunk("", anAsid(), aDateRange(), threshold)
 
 
 def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
     asid = anAsid()
-    date_range = {
-        "start_date": date(2021, 6, 29),
-        "end_date": date(2021, 7, 19)
-    }
+    date_range = aDateRange()
     threshold = "4537.33933970307"
     splunk_base_url = "https://test-splunk"
 
@@ -166,3 +135,8 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
 
 def anAsid():
     return "12345"
+
+
+def aDateRange():
+    return {"start_date": date(
+        2021, 4, 6), "end_date": date(2021, 6, 28)}

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -37,7 +37,7 @@ def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
     baseline_threshold = get_baseline_threshold_from_splunk_data(
-        asid, baseline_date_range)
+        "", asid, baseline_date_range)
 
     assert baseline_threshold == "4537.33933970307"
 
@@ -53,7 +53,7 @@ def test_get_baseline_threshold_from_splunk_data_handles_no_results(splunk_respo
 "2021-09-06T00:00:00.000+0000",0,""0""", status=200)
 
     with pytest.raises(ValueError, match="Threshold is not a positive value"):
-        get_baseline_threshold_from_splunk_data(asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(splunk_response):
@@ -66,7 +66,7 @@ def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(s
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_baseline_threshold_from_splunk_data(asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_response):
@@ -80,17 +80,19 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
         read=lambda: "this-is-not-a-byte-string", status=200)
 
     with pytest.raises(SplunkParseError):
-        get_baseline_threshold_from_splunk_data(asid, baseline_date_range)
+        get_baseline_threshold_from_splunk_data("", asid, baseline_date_range)
 
 
-def test_get_baseline_threshold_from_splunk_data_has_correct_request_body(splunk_request):
+def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
     asid = "12345"
     baseline_date_range = {
         "start_date": date(2021, 4, 6),
         "end_date": date(2021, 6, 28)
     }
+    splunk_base_url = "https://test-splunk"
 
-    get_baseline_threshold_from_splunk_data(asid, baseline_date_range)
+    get_baseline_threshold_from_splunk_data(
+        splunk_base_url, asid, baseline_date_range)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -106,15 +108,15 @@ def test_get_baseline_threshold_from_splunk_data_has_correct_request_body(splunk
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     }
-    splunk_request.assert_called_once_with("POST", ANY, expected_request_body)
+    splunk_request.assert_called_once_with(
+        "POST", splunk_base_url, expected_request_body)
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
     asid = "12345"
     date_range = {
         "start_date": date(2021, 6, 29),
-        "end_date": date(2021, 7, 19)
-    }
+        "end_date": date(2021, 7, 19)}
     threshold = "4537.33933970307"
 
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -122,7 +122,7 @@ def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
     splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
-    telemetry = get_telemetry_from_splunk(asid, date_range, threshold)
+    telemetry = get_telemetry_from_splunk("", asid, date_range, threshold)
 
     assert telemetry == splunk_response.return_value
 
@@ -138,7 +138,7 @@ def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_telemetry_from_splunk(asid, date_range, threshold)
+        get_telemetry_from_splunk("", asid, date_range, threshold)
 
 
 def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
@@ -148,8 +148,9 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
         "end_date": date(2021, 7, 19)
     }
     threshold = "4537.33933970307"
+    splunk_base_url = "https://test-splunk"
 
-    get_telemetry_from_splunk(asid, date_range, threshold)
+    get_telemetry_from_splunk(splunk_base_url, asid, date_range, threshold)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -163,4 +164,5 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
 | eval avgmin2std={threshold}
 | fields - day_of_week"""
     }
-    splunk_request.assert_called_once_with("POST", ANY, expected_request_body)
+    splunk_request.assert_called_once_with(
+        "POST", f"{splunk_base_url}/search/jobs/export", expected_request_body)

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -109,7 +109,7 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 | fields - stdd"""
     }
     splunk_request.assert_called_once_with(
-        "POST", splunk_base_url, expected_request_body)
+        "POST", f"{splunk_base_url}/search/jobs/export", expected_request_body)
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):


### PR DESCRIPTION
Have the lambda take the base splunk URL from an environment variable and use that when calling the Splunk API.