### PR TITLE
PRACMIG-702: Fixed ip for splunk access

### DIFF
--- a/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
@@ -1,10 +1,14 @@
 resource "aws_lambda_function" "metrics_calculator_function" {
   function_name = var.metrics_calculator_function_name
-  role          = aws_iam_role.iam_for_lambda.arn
+  role          = aws_iam_role.metrics_calculator_function_role.arn
   handler       = var.metrics_calculator_handler_name
   timeout       = 120
+  runtime       = "python3.9"
 
-  runtime = "python3.9"
+  vpc_config {
+    security_group_ids = [aws_security_group.lambda_sg.id]
+    subnet_ids         = [aws_subnet.private_subnet.id]
+  }
 
   s3_bucket = var.metrics_calculator_deployment_bucket_name
   s3_key    = var.metrics_calculator_code_key
@@ -18,12 +22,66 @@ resource "aws_lambda_function" "metrics_calculator_function" {
     }
   }
 }
+
+resource "aws_lambda_function" "splunk_data_exporter_function" {
+  function_name = var.splunk_data_exporter_function_name
+  role          = aws_iam_role.splunk_data_exporter_function_role.arn
+  handler       = var.splunk_data_exporter_handler_name
+  timeout       = 120
+  runtime       = "python3.9"
+
+  vpc_config {
+    security_group_ids = [aws_security_group.lambda_sg.id]
+    subnet_ids         = [aws_subnet.private_subnet.id]
+  }
+
+  s3_bucket = var.metrics_calculator_deployment_bucket_name
+  s3_key    = var.metrics_calculator_code_key
+
+  environment {
+    variables = {
+      ASID_LOOKUP_BUCKET_NAME = var.asid_lookup_bucket_name
+      OCCURRENCES_BUCKET_NAME = var.migration_occurrences_bucket_name
+      TELEMETRY_BUCKET_NAME   = var.telemetry_bucket_name
+      SPLUNK_BASE_URL         = var.splunk_api_base_url
     }
   }
 }
 
-resource "aws_iam_role" "iam_for_lambda" {
-  name = "iam_for_lambda"
+resource "aws_security_group" "lambda_sg" {
+  vpc_id = aws_vpc.metrics_calculator_vpc.id
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_iam_role" "metrics_calculator_function_role" {
+  name = "metrics_calculator_function_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "splunk_data_exporter_function_role" {
+  name = "splunk_data_exporter_function_role"
 
   assume_role_policy = <<EOF
 {
@@ -97,12 +155,65 @@ resource "aws_iam_policy" "metrics_calculator_function_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "splunk_data_exporter_function_policy" {
+  name        = "AllowSplunkDataExporterS3Access"
+  description = "Grant the splunk data exporter function the required S3 permissions"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowReadOccurrencesBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${var.migration_occurrences_bucket_name}"
+    },
+    {
+      "Sid": "AllowReadOccurrencesObjects",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${var.migration_occurrences_bucket_name}/*"
+    },
+    {
+      "Sid": "AllowReadAsidLookupBucket",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${var.asid_lookup_bucket_name}"
+    },
+    {
+      "Sid": "AllowReadAsidLookupObjects",
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::${var.asid_lookup_bucket_name}/*"
+    },
+    {
+      "Sid": "AllowWriteTelemetryData",
+      "Effect": "Allow",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${var.telemetry_bucket_name}"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy_attachment" "metrics_calculator_function_execution_policy" {
-  role       = aws_iam_role.iam_for_lambda.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.metrics_calculator_function_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "splunk_data_exporter_function_execution_policy" {
+  role       = aws_iam_role.splunk_data_exporter_function_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "metrics_calculator_function_s3_policy" {
-  role       = aws_iam_role.iam_for_lambda.name
+  role       = aws_iam_role.metrics_calculator_function_role.name
   policy_arn = aws_iam_policy.metrics_calculator_function_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "splunk_data_exporter_function_s3_policy" {
+  role       = aws_iam_role.splunk_data_exporter_function_role.name
+  policy_arn = aws_iam_policy.splunk_data_exporter_function_policy.arn
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
@@ -43,7 +43,7 @@ resource "aws_lambda_function" "splunk_data_exporter_function" {
       ASID_LOOKUP_BUCKET_NAME = var.asid_lookup_bucket_name
       OCCURRENCES_BUCKET_NAME = var.migration_occurrences_bucket_name
       TELEMETRY_BUCKET_NAME   = var.telemetry_bucket_name
-      SPLUNK_BASE_URL         = var.splunk_api_base_url
+      SPLUNK_HOST             = var.splunk_api_host
     }
   }
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
@@ -4,17 +4,20 @@ resource "aws_lambda_function" "metrics_calculator_function" {
   handler       = var.metrics_calculator_handler_name
   timeout       = 120
 
-  runtime       = "python3.9"
+  runtime = "python3.9"
 
-  s3_bucket     = var.metrics_calculator_deployment_bucket_name
-  s3_key        = var.metrics_calculator_code_key
+  s3_bucket = var.metrics_calculator_deployment_bucket_name
+  s3_key    = var.metrics_calculator_code_key
 
   environment {
     variables = {
-      ASID_LOOKUP_BUCKET_NAME   = var.asid_lookup_bucket_name
-      METRICS_BUCKET_NAME   = var.metrics_bucket_name
-      OCCURRENCES_BUCKET_NAME   = var.migration_occurrences_bucket_name
-      TELEMETRY_BUCKET_NAME = var.telemetry_bucket_name
+      ASID_LOOKUP_BUCKET_NAME = var.asid_lookup_bucket_name
+      METRICS_BUCKET_NAME     = var.metrics_bucket_name
+      OCCURRENCES_BUCKET_NAME = var.migration_occurrences_bucket_name
+      TELEMETRY_BUCKET_NAME   = var.telemetry_bucket_name
+    }
+  }
+}
     }
   }
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/terraform.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/terraform.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = var.region
+  region = var.region
 
   default_tags {
     tags = {

--- a/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
@@ -48,16 +48,17 @@ variable "metrics_calculator_function_name" {
 }
 
 variable "metrics_calculator_deployment_bucket_name" {
-  type    = string
+  type        = string
   description = "Name of bucket where the metrics calculator package is deployed"
 }
 
 variable "metrics_calculator_code_key" {
-  type    = string
+  type        = string
   description = "Object key for metrics calculator deployed code"
 }
 
 variable "metrics_calculator_handler_name" {
-  type    = string
+  type        = string
   description = "Handler function name for the metrics calculator"
+}
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
@@ -61,4 +61,18 @@ variable "metrics_calculator_handler_name" {
   type        = string
   description = "Handler function name for the metrics calculator"
 }
+
+variable "splunk_data_exporter_function_name" {
+  type    = string
+  default = "splunk_data_exporter"
+}
+
+variable "splunk_data_exporter_handler_name" {
+  type        = string
+  description = "Handler function name for the metrics calculator"
+}
+
+variable "splunk_api_base_url" {
+  type        = string
+  description = "Base URL for accessing the Splunk API"
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
@@ -72,7 +72,7 @@ variable "splunk_data_exporter_handler_name" {
   description = "Handler function name for the metrics calculator"
 }
 
-variable "splunk_api_base_url" {
+variable "splunk_api_host" {
   type        = string
-  description = "Base URL for accessing the Splunk API"
+  description = "Splunk API hostname"
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/vpc.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/vpc.tf
@@ -1,0 +1,87 @@
+resource "aws_vpc" "metrics_calculator_vpc" {
+  cidr_block = "10.0.0.0/26"
+
+  tags = {
+    Name = "VPC for the metrics calculator lambdas"
+  }
+}
+
+resource "aws_subnet" "public_subnet" {
+  vpc_id               = aws_vpc.metrics_calculator_vpc.id
+  cidr_block           = "10.0.0.0/28"
+  availability_zone_id = data.aws_availability_zones.available.zone_ids[0]
+
+  depends_on = [aws_internet_gateway.gw]
+
+  tags = {
+    Name = "Metrics calculator VPC public subnet"
+  }
+}
+
+resource "aws_subnet" "private_subnet" {
+  vpc_id               = aws_vpc.metrics_calculator_vpc.id
+  cidr_block           = "10.0.0.16/28"
+  availability_zone_id = data.aws_availability_zones.available.zone_ids[0]
+
+  tags = {
+    Name = "Metrics calculator VPC private subnet"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.metrics_calculator_vpc.id
+}
+
+resource "aws_nat_gateway" "ngw" {
+  allocation_id = aws_eip.ngw_public_ip.id
+  subnet_id     = aws_subnet.public_subnet.id
+
+  # To ensure proper ordering, it is recommended to add an explicit dependency
+  # on the Internet Gateway for the VPC.
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_eip" "ngw_public_ip" {
+  vpc = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_route_table" "public_subnet_route_table" {
+  vpc_id = aws_vpc.metrics_calculator_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gw.id
+  }
+}
+
+resource "aws_route_table" "private_subnet_route_table" {
+  vpc_id = aws_vpc.metrics_calculator_vpc.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.ngw.id
+  }
+}
+
+resource "aws_route_table_association" "public_route_table" {
+  subnet_id      = aws_subnet.public_subnet.id
+  route_table_id = aws_route_table.public_subnet_route_table.id
+}
+
+resource "aws_route_table_association" "private_route_table" {
+  subnet_id      = aws_subnet.private_subnet.id
+  route_table_id = aws_route_table.private_subnet_route_table.id
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+
+  filter { # Only fetch Availability Zones (no Local Zones)
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}

--- a/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
+++ b/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
@@ -7,5 +7,5 @@
   "metrics_calculator_code_key": "df969c53c734da200719b917c0c78bb7",
   "metrics_calculator_handler_name": "app.calculate_dashboard_metrics_from_telemetry",
   "splunk_data_exporter_handler_name": "app.export_splunk_data",
-  "splunk_api_base_url": ""
+  "splunk_api_host": ""
 }

--- a/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
+++ b/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
@@ -4,6 +4,8 @@
   "migration_occurrences_bucket_name": "prm-pracmig-migration-occurrences-dev",
   "metrics_bucket_name": "prm-pracmig-metrics-dev",
   "metrics_calculator_deployment_bucket_name": "prm-pracmig-metrics-calculator-deployments-dev",
-  "metrics_calculator_code_key": "5a6758922f547ac9593332311fcc5582",
-  "metrics_calculator_handler_name": "app.calculate_dashboard_metrics_from_telemetry"
+  "metrics_calculator_code_key": "df969c53c734da200719b917c0c78bb7",
+  "metrics_calculator_handler_name": "app.calculate_dashboard_metrics_from_telemetry",
+  "splunk_data_exporter_handler_name": "app.export_splunk_data",
+  "splunk_api_base_url": ""
 }

--- a/metrics-calculator/.chalice/config.json
+++ b/metrics-calculator/.chalice/config.json
@@ -17,7 +17,7 @@
             "OCCURRENCES_BUCKET_NAME": "prm-pracmig-migration-occurrences-dev",
             "ASID_LOOKUP_BUCKET_NAME": "prm-pracmig-asid-lookup-dev",
             "TELEMETRY_BUCKET_NAME": "prm-pracmig-telemetry-dev",
-            "SPLUNK_BASE_URL": "https://dev.splunk.url"
+            "SPLUNK_HOST": "dev.splunk.url"
           }
         }
       }

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -71,7 +71,7 @@ def export_splunk_data(event, context):
     occurrences_bucket_name = os.environ['OCCURRENCES_BUCKET_NAME']
     asid_lookup_bucket_name = os.environ['ASID_LOOKUP_BUCKET_NAME']
     telemetry_bucket_name = os.environ['TELEMETRY_BUCKET_NAME']
-    splunk_base_url = os.environ['SPLUNK_BASE_URL']
+    splunk_host = os.environ['SPLUNK_HOST']
 
     s3 = get_s3_resource()
     known_migrations = get_migration_occurrences(
@@ -91,16 +91,16 @@ def export_splunk_data(event, context):
             migration["date"])
 
         baseline_threshold = get_baseline_threshold_from_splunk_data(
-            splunk_base_url, old_asid, baseline_date_range)
+            splunk_host, old_asid, baseline_date_range)
 
         pre_cutover_telemetry = get_telemetry_from_splunk(
-            splunk_base_url,
+            splunk_host,
             old_asid,
             baseline_threshold,
             pre_cutover_date_range
         )
         post_cutover_telemetry = get_telemetry_from_splunk(
-            splunk_base_url,
+            splunk_host,
             new_asid,
             baseline_threshold,
             post_cutover_date_range

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -66,7 +66,7 @@ def calculate_dashboard_metrics_from_telemetry(event, context):
     return "ok"
 
 
-@app.lambda_function(name='export-splunk-data')
+@app.lambda_function(name='splunk-data-exporter')
 def export_splunk_data(event, context):
     occurrences_bucket_name = os.environ['OCCURRENCES_BUCKET_NAME']
     asid_lookup_bucket_name = os.environ['ASID_LOOKUP_BUCKET_NAME']
@@ -109,9 +109,15 @@ def export_splunk_data(event, context):
         pre_cutover_telemetry_filename = f"{old_asid}-telemetry.csv.gz"
         post_cutover_telemetry_filename = f"{new_asid}-telemetry.csv.gz"
         upload_telemetry(
-            s3, telemetry_bucket_name, pre_cutover_telemetry, pre_cutover_telemetry_filename)
+            s3,
+            telemetry_bucket_name,
+            pre_cutover_telemetry,
+            pre_cutover_telemetry_filename)
         upload_telemetry(
-            s3, telemetry_bucket_name, post_cutover_telemetry, post_cutover_telemetry_filename)
+            s3,
+            telemetry_bucket_name,
+            post_cutover_telemetry,
+            post_cutover_telemetry_filename)
 
     return "ok"
 

--- a/metrics-calculator/chalicelib/get_data_from_splunk.py
+++ b/metrics-calculator/chalicelib/get_data_from_splunk.py
@@ -11,14 +11,14 @@ class SplunkParseError(Exception):
 
 
 def get_baseline_threshold_from_splunk_data(
-        splunk_base_url, asid, baseline_date_range):
+        splunk_host, asid, baseline_date_range):
     response = make_request_for_baseline_telemetry(
-        splunk_base_url, asid, baseline_date_range)
+        splunk_host, asid, baseline_date_range)
     threshold = parse_threshold_from_splunk_response(response)
     return threshold
 
 
-def get_telemetry_from_splunk(splunk_base_url, asid, date_range, baseline_threshold):
+def get_telemetry_from_splunk(splunk_host, asid, date_range, baseline_threshold):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | timechart span=1d count
 | fillnull
@@ -26,11 +26,11 @@ def get_telemetry_from_splunk(splunk_base_url, asid, date_range, baseline_thresh
 | where NOT (day_of_week="Saturday" OR day_of_week="Sunday")
 | eval avgmin2std={baseline_threshold}
 | fields - day_of_week"""
-    response = make_splunk_request(splunk_base_url, date_range, search_text)
+    response = make_splunk_request(splunk_host, date_range, search_text)
     return response
 
 
-def make_request_for_baseline_telemetry(splunk_base_url, asid, baseline_date_range):
+def make_request_for_baseline_telemetry(splunk_host, asid, baseline_date_range):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | bucket span=1d _time
 | eval day_of_week = strftime(_time,"%A")
@@ -41,12 +41,12 @@ def make_request_for_baseline_telemetry(splunk_base_url, asid, baseline_date_ran
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     response = make_splunk_request(
-        splunk_base_url, baseline_date_range, search_text)
+        splunk_host, baseline_date_range, search_text)
     return response
 
 
-def make_splunk_request(splunk_base_url, date_range, search_text):
-    connection = HTTPSConnection(splunk_base_url)
+def make_splunk_request(splunk_host, date_range, search_text):
+    connection = HTTPSConnection(splunk_host)
     connection.connect()
     request_body = {
         "output_mode": "csv",

--- a/metrics-calculator/scripts/build-and-package.sh
+++ b/metrics-calculator/scripts/build-and-package.sh
@@ -35,8 +35,9 @@ aws cloudformation package \
 
 # Outputs to use in tfvars on the metrics calculator stack
 JSON=$(cat "./build/packaged-cf.json")
-HANDLER=$(echo "${JSON}" | jq .Resources.CalculateDashboardMetricsFromTelemetry.Properties.Handler | tr -d '"')
+METRICS_CALC_HANDLER=$(echo "${JSON}" | jq .Resources.CalculateDashboardMetricsFromTelemetry.Properties.Handler | tr -d '"')
+SPLUNK_EXPORTER_HANDLER=$(echo "${JSON}" | jq .Resources.SplunkDataExporter.Properties.Handler | tr -d '"')
 CODE_URI=$(echo "${JSON}" | jq .Resources.CalculateDashboardMetricsFromTelemetry.Properties.CodeUri | tr -d '"' | cut -c 7-)
 OBJECT_KEY="${CODE_URI#*/}"
 echo "Merge the below into the metrics calculator stack's Terraform vars file:"
-echo "{ \"metrics_calculator_deployment_bucket_name\": \"${BUCKET_NAME}\", \"metrics_calculator_code_key\": \"${OBJECT_KEY}\", \"metrics_calculator_handler_name\": \"${HANDLER}\" }" | jq
+echo "{ \"metrics_calculator_deployment_bucket_name\": \"${BUCKET_NAME}\", \"metrics_calculator_code_key\": \"${OBJECT_KEY}\", \"metrics_calculator_handler_name\": \"${METRICS_CALC_HANDLER}\", \"splunk_data_exporter_handler_name\": \"${SPLUNK_EXPORTER_HANDLER}\" }" | jq

--- a/metrics-calculator/tests/service/test_app_service.py
+++ b/metrics-calculator/tests/service/test_app_service.py
@@ -113,7 +113,7 @@ def test_export_splunk_data(
         asid_lookup_bucket_name, s3, ods_code, old_asid, new_asid)
     create_mock_splunk_data(splunk, old_asid)
 
-    response = test_client.lambda_.invoke('export-splunk-data')
+    response = test_client.lambda_.invoke('splunk-data-exporter')
     assert response.payload == "ok"
 
     pre_cutover_telemetry_obj = telemetry_bucket_name.Object(

--- a/metrics-calculator/tests/unit/test_app.py
+++ b/metrics-calculator/tests/unit/test_app.py
@@ -429,7 +429,7 @@ def test_export_splunk_data_queries_splunk_for_baseline_threshold(
     export_splunk_data({}, {})
 
     get_baseline_threshold_from_splunk_data_mock.assert_called_once_with(
-        exporter_lambda_env_vars["SPLUNK_BASE_URL"],
+        exporter_lambda_env_vars["SPLUNK_HOST"],
         old_asid,
         calculate_baseline_date_range_mock.return_value)
 
@@ -462,12 +462,12 @@ def test_export_splunk_data_queries_splunk_data_using_baseline_threshold(
     export_splunk_data({}, {})
 
     get_telemetry_from_splunk_mock.assert_any_call(
-        exporter_lambda_env_vars["SPLUNK_BASE_URL"],
+        exporter_lambda_env_vars["SPLUNK_HOST"],
         old_asid,
         baseline_threshold,
         calculate_pre_cutover_date_range_mock.return_value)
     get_telemetry_from_splunk_mock.assert_any_call(
-        exporter_lambda_env_vars["SPLUNK_BASE_URL"],
+        exporter_lambda_env_vars["SPLUNK_HOST"],
         new_asid,
         baseline_threshold,
         calculate_post_cutover_date_range_mock.return_value)

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -68,10 +68,10 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
     asid = anAsid()
     baseline_date_range = aDateRange()
-    splunk_base_url = "test-splunk"
+    splunk_host = "test-splunk"
 
     get_baseline_threshold_from_splunk_data(
-        splunk_base_url, asid, baseline_date_range)
+        splunk_host, asid, baseline_date_range)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -87,7 +87,7 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     }
-    splunk_request["connection"].assert_called_once_with(splunk_base_url)
+    splunk_request["connection"].assert_called_once_with(splunk_host)
     splunk_request["request"].assert_called_once_with(
         "POST", "/search/jobs/export", expected_request_body)
 
@@ -117,9 +117,9 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
     asid = anAsid()
     date_range = aDateRange()
     threshold = "4537.33933970307"
-    splunk_base_url = "test-splunk"
+    splunk_host = "test-splunk"
 
-    get_telemetry_from_splunk(splunk_base_url, asid, date_range, threshold)
+    get_telemetry_from_splunk(splunk_host, asid, date_range, threshold)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -133,7 +133,7 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
 | eval avgmin2std={threshold}
 | fields - day_of_week"""
     }
-    splunk_request["connection"].assert_called_once_with(splunk_base_url)
+    splunk_request["connection"].assert_called_once_with(splunk_host)
     splunk_request["request"].assert_called_once_with(
         "POST", "/search/jobs/export", expected_request_body)
 

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -25,7 +25,10 @@ def splunk_request(monkeypatch):
         request=request_mock, getresponse=Mock(return_value=response_mock)))
     monkeypatch.setattr(
         "chalicelib.get_data_from_splunk.HTTPSConnection", connection_mock)
-    yield request_mock
+    yield {
+        "connection": connection_mock,
+        "request": request_mock
+    }
 
 
 def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_telemetry(splunk_response):
@@ -65,7 +68,7 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
     asid = anAsid()
     baseline_date_range = aDateRange()
-    splunk_base_url = "https://test-splunk"
+    splunk_base_url = "test-splunk"
 
     get_baseline_threshold_from_splunk_data(
         splunk_base_url, asid, baseline_date_range)
@@ -84,8 +87,9 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     }
-    splunk_request.assert_called_once_with(
-        "POST", f"{splunk_base_url}/search/jobs/export", expected_request_body)
+    splunk_request["connection"].assert_called_once_with(splunk_base_url)
+    splunk_request["request"].assert_called_once_with(
+        "POST", "/search/jobs/export", expected_request_body)
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
@@ -113,7 +117,7 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
     asid = anAsid()
     date_range = aDateRange()
     threshold = "4537.33933970307"
-    splunk_base_url = "https://test-splunk"
+    splunk_base_url = "test-splunk"
 
     get_telemetry_from_splunk(splunk_base_url, asid, date_range, threshold)
 
@@ -129,8 +133,9 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
 | eval avgmin2std={threshold}
 | fields - day_of_week"""
     }
-    splunk_request.assert_called_once_with(
-        "POST", f"{splunk_base_url}/search/jobs/export", expected_request_body)
+    splunk_request["connection"].assert_called_once_with(splunk_base_url)
+    splunk_request["request"].assert_called_once_with(
+        "POST", "/search/jobs/export", expected_request_body)
 
 
 def anAsid():


### PR DESCRIPTION
Deploy splunk data exporter lambda (and metrics calculator lambda) into a VPC with internet access so that it can call out to the Splunk API (once we have an API key).