### PR TITLE
PRACMIG-693: Splunk API access token

### DIFF
--- a/dashboard-infra/stacks/metrics-calculator/terraform/data.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_role" "nhsd_admin_role" {
+  name = "NHSDAdminRole"
+}

--- a/dashboard-infra/stacks/metrics-calculator/terraform/kms.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/kms.tf
@@ -1,0 +1,51 @@
+resource "aws_kms_key" "splunk_api_token_encryption_key" {
+  description = "KMS key to use for encrypting/decrypting the Splunk API token"
+  policy      = <<EOF
+{
+  "Version" : "2012-10-17",
+  "Statement" : [
+    {
+      "Sid": "SplunkApiTokenKmsKeyAdmin",
+      "Effect": "Allow",
+      "Principal": {"AWS": "${data.aws_iam_role.nhsd_admin_role.arn}"},
+      "Action": [
+        "kms:Create*",
+        "kms:Describe*",
+        "kms:Enable*",
+        "kms:List*",
+        "kms:Put*",
+        "kms:Update*",
+        "kms:Revoke*",
+        "kms:Disable*",
+        "kms:Get*",
+        "kms:Delete*",
+        "kms:TagResource",
+        "kms:UntagResource",
+        "kms:ScheduleKeyDeletion",
+        "kms:CancelKeyDeletion"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SplunkApiTokenKmsKeyAdminUse",
+      "Effect": "Allow",
+      "Principal": {"AWS": "${data.aws_iam_role.nhsd_admin_role.arn}"},
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid" : "AllowSplunkDataExporterToDecryptUsingSplunkTokenEncryptionKey",
+      "Effect" : "Allow",
+      "Principal" : {
+        "AWS" : "${aws_iam_role.splunk_data_exporter_function_role.arn}"
+      },
+      "Action" : "kms:Decrypt",
+      "Resource" : "*"
+    }
+  ]
+}
+EOF
+}

--- a/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/lambda.tf
@@ -198,6 +198,25 @@ resource "aws_iam_policy" "splunk_data_exporter_function_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "splunk_api_token_access_policy" {
+  name        = "AllowAccessToSplunkApiToken"
+  description = "Grant read access to the API token used to authenticate with Splunk"
+  policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+          "ssm:GetParameter*"
+      ],
+      "Resource": "arn:aws:ssm:${var.region}:${data.aws_caller_identity.current.account_id}:parameter${var.splunk_api_token_param_name}"
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_iam_role_policy_attachment" "metrics_calculator_function_execution_policy" {
   role       = aws_iam_role.metrics_calculator_function_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
@@ -216,4 +235,9 @@ resource "aws_iam_role_policy_attachment" "metrics_calculator_function_s3_policy
 resource "aws_iam_role_policy_attachment" "splunk_data_exporter_function_s3_policy" {
   role       = aws_iam_role.splunk_data_exporter_function_role.name
   policy_arn = aws_iam_policy.splunk_data_exporter_function_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "splunk_data_exporter_splunk_api_token_policy" {
+  role       = aws_iam_role.splunk_data_exporter_function_role.name
+  policy_arn = aws_iam_policy.splunk_api_token_access_policy.arn
 }

--- a/dashboard-infra/stacks/metrics-calculator/terraform/ssm.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/ssm.tf
@@ -1,0 +1,7 @@
+resource "aws_ssm_parameter" "splunk_api_token" {
+  name        = var.splunk_api_token_param_name
+  description = "API token to be used for authenticating with Splunk"
+  type        = "SecureString"
+  value       = "dummy-api-token-value"
+  key_id      = aws_kms_key.splunk_api_token_encryption_key.id
+}

--- a/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
+++ b/dashboard-infra/stacks/metrics-calculator/terraform/variables.tf
@@ -76,3 +76,8 @@ variable "splunk_api_host" {
   type        = string
   description = "Splunk API hostname"
 }
+
+variable "splunk_api_token_param_name" {
+  type        = string
+  description = "Name of the parameter in SSM Parameter Store containing the Splunk API token"
+}

--- a/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
+++ b/dashboard-infra/stacks/metrics-calculator/vars/dev.tfvars.json
@@ -7,5 +7,6 @@
   "metrics_calculator_code_key": "df969c53c734da200719b917c0c78bb7",
   "metrics_calculator_handler_name": "app.calculate_dashboard_metrics_from_telemetry",
   "splunk_data_exporter_handler_name": "app.export_splunk_data",
-  "splunk_api_host": ""
+  "splunk_api_host": "",
+  "splunk_api_token_param_name": "/prod/splunk-api-token"
 }

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -82,6 +82,7 @@ def export_splunk_data(event, context):
             s3, asid_lookup_bucket_name, migration)
         old_asid = asid_lookup["old"]["asid"]
         new_asid = asid_lookup["new"]["asid"]
+        token = "this-is-a-token"
 
         baseline_date_range = calculate_baseline_date_range(
             migration["date"])
@@ -91,19 +92,21 @@ def export_splunk_data(event, context):
             migration["date"])
 
         baseline_threshold = get_baseline_threshold_from_splunk_data(
-            splunk_host, old_asid, baseline_date_range)
+            splunk_host, token, old_asid, baseline_date_range)
 
         pre_cutover_telemetry = get_telemetry_from_splunk(
             splunk_host,
+            token,
             old_asid,
-            baseline_threshold,
-            pre_cutover_date_range
+            pre_cutover_date_range,
+            baseline_threshold
         )
         post_cutover_telemetry = get_telemetry_from_splunk(
             splunk_host,
+            token,
             new_asid,
-            baseline_threshold,
-            post_cutover_date_range
+            post_cutover_date_range,
+            baseline_threshold
         )
 
         pre_cutover_telemetry_filename = f"{old_asid}-telemetry.csv.gz"

--- a/metrics-calculator/app.py
+++ b/metrics-calculator/app.py
@@ -10,7 +10,7 @@ from chalicelib.lookup_asids import AsidLookupError, lookup_asids
 from chalicelib.metrics_engine import calculate_cutover_start_and_end_date
 from chalicelib.migration_occurrences import get_migration_occurrences
 from chalicelib.s3 import get_s3_resource, write_object_s3
-from chalicelib.telemetry import get_telemetry
+from chalicelib.telemetry import get_telemetry, upload_telemetry
 from chalicelib.calculate_date_range import calculate_baseline_date_range, calculate_pre_cutover_date_range, calculate_post_cutover_date_range
 
 app = Chalice(app_name='metrics-calculator')
@@ -134,7 +134,3 @@ def calculate_mean_cutover(metrics):
     rounded_mean = Decimal(mean).quantize(
         Decimal('.1'), rounding=ROUND_HALF_UP)
     return f"{rounded_mean}"
-
-
-def upload_telemetry(s3, bucket_name, telemetry_data, filename):
-    pass

--- a/metrics-calculator/chalicelib/get_data_from_splunk.py
+++ b/metrics-calculator/chalicelib/get_data_from_splunk.py
@@ -11,14 +11,14 @@ class SplunkParseError(Exception):
 
 
 def get_baseline_threshold_from_splunk_data(
-        splunk_host, asid, baseline_date_range):
+        splunk_host, token, asid, baseline_date_range):
     telemetry = make_request_for_baseline_telemetry(
-        splunk_host, asid, baseline_date_range)
+        splunk_host, token, asid, baseline_date_range)
     threshold = parse_threshold_from_telemetry(telemetry)
     return threshold
 
 
-def get_telemetry_from_splunk(splunk_host, asid, date_range, baseline_threshold):
+def get_telemetry_from_splunk(splunk_host, token, asid, date_range, baseline_threshold):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | timechart span=1d count
 | fillnull
@@ -26,11 +26,12 @@ def get_telemetry_from_splunk(splunk_host, asid, date_range, baseline_threshold)
 | where NOT (day_of_week="Saturday" OR day_of_week="Sunday")
 | eval avgmin2std={baseline_threshold}
 | fields - day_of_week"""
-    telemetry = make_splunk_request(splunk_host, date_range, search_text)
+    telemetry = make_splunk_request(
+        splunk_host, token, date_range, search_text)
     return telemetry
 
 
-def make_request_for_baseline_telemetry(splunk_host, asid, baseline_date_range):
+def make_request_for_baseline_telemetry(splunk_host, token, asid, baseline_date_range):
     search_text = f"""index="spine2vfmmonitor" messageSender={asid}
 | bucket span=1d _time
 | eval day_of_week = strftime(_time,"%A")
@@ -41,11 +42,11 @@ def make_request_for_baseline_telemetry(splunk_host, asid, baseline_date_range):
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     telemetry = make_splunk_request(
-        splunk_host, baseline_date_range, search_text)
+        splunk_host, token, baseline_date_range, search_text)
     return telemetry
 
 
-def make_splunk_request(splunk_host, date_range, search_text):
+def make_splunk_request(splunk_host, token, date_range, search_text):
     connection = HTTPSConnection(splunk_host)
     connection.connect()
     request_body = {
@@ -54,7 +55,9 @@ def make_splunk_request(splunk_host, date_range, search_text):
         "latest_time": date_range["end_date"],
         "search": search_text
     }
-    connection.request('POST', "/search/jobs/export", request_body)
+    headers = {"Authorization": f"Bearer {token}"}
+    connection.request('POST', "/search/jobs/export", request_body, headers)
+
     response = connection.getresponse()
     if response.status != 200:
         raise SplunkQueryError(

--- a/metrics-calculator/chalicelib/get_splunk_api_token.py
+++ b/metrics-calculator/chalicelib/get_splunk_api_token.py
@@ -1,3 +1,4 @@
 def get_splunk_api_token(ssm, parameter_name):
-    parameter_details = ssm.get_parameter(Name=parameter_name)
+    parameter_details = ssm.get_parameter(
+        Name=parameter_name, WithDecryption=True)
     return parameter_details['Parameter']['Value']

--- a/metrics-calculator/chalicelib/get_splunk_api_token.py
+++ b/metrics-calculator/chalicelib/get_splunk_api_token.py
@@ -1,0 +1,3 @@
+def get_splunk_api_token(ssm, parameter_name):
+    parameter_details = ssm.get_parameter(Name=parameter_name)
+    return parameter_details['Parameter']['Value']

--- a/metrics-calculator/chalicelib/telemetry.py
+++ b/metrics-calculator/chalicelib/telemetry.py
@@ -1,4 +1,5 @@
-from chalicelib.s3 import read_object_s3
+import gzip
+from chalicelib.s3 import read_object_s3, write_object_s3
 from chalicelib.csv_rows import csv_rows
 
 
@@ -7,3 +8,8 @@ def get_telemetry(s3, telemetry_bucket_name, new_telemetry_object_name):
         s3, f"s3://{telemetry_bucket_name}/{new_telemetry_object_name}")
     new_telemetry_generator = csv_rows(new_telemetry_stream)
     return new_telemetry_generator
+
+
+def upload_telemetry(s3, bucket_name, telemetry_data, filename):
+    zipped_telemetry = gzip.compress(telemetry_data)
+    write_object_s3(s3, f"s3://{bucket_name}/{filename}", zipped_telemetry)

--- a/metrics-calculator/tests/integration/test_get_splunk_api_token.py
+++ b/metrics-calculator/tests/integration/test_get_splunk_api_token.py
@@ -1,0 +1,34 @@
+import boto3
+import os
+import pytest
+
+from moto import mock_ssm
+from chalicelib.get_splunk_api_token import get_splunk_api_token
+
+
+@pytest.fixture(scope='function')
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
+
+@pytest.fixture(scope='function')
+def ssm(aws_credentials):
+    with mock_ssm():
+        yield boto3.client('ssm', region_name='us-east-1')
+
+
+def test_get_splunk_api_token_returns_api_token(ssm):
+    expected_token_value = "this-is-a-token"
+    parameter_name = "Splunk API token"
+    ssm.put_parameter(Name=parameter_name, Value=expected_token_value, Type="String")
+
+    returned_token_value = get_splunk_api_token(ssm, parameter_name)
+    assert returned_token_value == expected_token_value
+
+
+

--- a/metrics-calculator/tests/integration/test_get_splunk_api_token.py
+++ b/metrics-calculator/tests/integration/test_get_splunk_api_token.py
@@ -25,10 +25,11 @@ def ssm(aws_credentials):
 def test_get_splunk_api_token_returns_api_token(ssm):
     expected_token_value = "this-is-a-token"
     parameter_name = "Splunk API token"
-    ssm.put_parameter(Name=parameter_name, Value=expected_token_value, Type="String")
+    ssm.put_parameter(
+        Name=parameter_name,
+        KeyId="custom-key-id",
+        Value=expected_token_value, Type="SecureString")
 
     returned_token_value = get_splunk_api_token(ssm, parameter_name)
+
     assert returned_token_value == expected_token_value
-
-
-

--- a/metrics-calculator/tests/integration/test_telemetry.py
+++ b/metrics-calculator/tests/integration/test_telemetry.py
@@ -1,0 +1,41 @@
+import gzip
+import boto3
+import os
+import pytest
+
+from moto import mock_s3
+from chalicelib.csv_rows import csv_rows
+from chalicelib.s3 import read_object_s3
+
+from chalicelib.telemetry import upload_telemetry
+
+
+@pytest.fixture(scope='function')
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+    os.environ['AWS_ACCESS_KEY_ID'] = 'testing'
+    os.environ['AWS_SECRET_ACCESS_KEY'] = 'testing'
+    os.environ['AWS_SECURITY_TOKEN'] = 'testing'
+    os.environ['AWS_SESSION_TOKEN'] = 'testing'
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+
+
+@pytest.fixture(scope='function')
+def s3(aws_credentials):
+    with mock_s3():
+        yield boto3.resource('s3', region_name='us-east-1')
+
+
+def test_upload_telemetry(s3):
+    bucket_name = "bucket-name"
+    telemetry_data = b"telemetry-data"
+    filename = "telemetry-file"
+    s3.create_bucket(Bucket=bucket_name)
+
+    upload_telemetry(s3, bucket_name, telemetry_data, filename)
+
+    uploaded_telemetry = read_object_s3(s3, f"s3://{bucket_name}/{filename}")
+    telemetry_string = uploaded_telemetry.read()
+    unzipped_telemetry = gzip.decompress(telemetry_string)
+
+    assert unzipped_telemetry == telemetry_data

--- a/metrics-calculator/tests/service/test_app_service.py
+++ b/metrics-calculator/tests/service/test_app_service.py
@@ -1,3 +1,5 @@
+import gzip
+
 import boto3
 import json
 import pytest
@@ -43,29 +45,43 @@ def test_client():
 
 
 @pytest.fixture(scope="function")
-def splunk(monkeypatch):
-    request_mock = Mock()
-    splunk_call_mock = Mock(return_value=MagicMock(getresponse=request_mock))
-    monkeypatch.setattr("app.HTTPSConnection", splunk_call_mock)
-    yield request_mock
+def splunk_response(monkeypatch):
+    response_mock = Mock()
+    connection_mock = Mock(return_value=MagicMock(getresponse=response_mock))
+    monkeypatch.setattr(
+        "chalicelib.get_data_from_splunk.HTTPSConnection", connection_mock)
+    yield response_mock
 
 
 @pytest.fixture(scope="function")
-def lambda_environment_vars():
-    with open('.chalice/config.json') as f:
+def calculator_lambda_env_vars():
+    with open(".chalice/config.json") as f:
         config = json.loads(f.read())
-        yield config["stages"]["dev"]["lambda_functions"]["calculate_dashboard_metrics_from_telemetry"]["environment_variables"]
+        vars = config["stages"]["dev"]["lambda_functions"]["calculate_dashboard_metrics_from_telemetry"]["environment_variables"]
+        for key in vars:
+            os.environ[key] = vars[key]
+        yield vars
+
+
+@pytest.fixture(scope="function")
+def exporter_lambda_env_vars():
+    with open(".chalice/config.json") as f:
+        config = json.loads(f.read())
+        vars = config["stages"]["dev"]["lambda_functions"]["export_splunk_data"]["environment_variables"]
+        for key in vars:
+            os.environ[key] = vars[key]
+        yield vars
 
 
 def test_calculate_dashboard_metrics_from_telemetry(
-        test_client, lambda_environment_vars, s3):
+        test_client, calculator_lambda_env_vars, s3):
     ods_code = "A12345"
     old_asid = "1234"
     new_asid = "5678"
-    occurrences_bucket_name = lambda_environment_vars["OCCURRENCES_BUCKET_NAME"]
-    asid_lookup_bucket_name = lambda_environment_vars["ASID_LOOKUP_BUCKET_NAME"]
-    telemetry_bucket_name = lambda_environment_vars["TELEMETRY_BUCKET_NAME"]
-    metrics_bucket_name = lambda_environment_vars["METRICS_BUCKET_NAME"]
+    occurrences_bucket_name = calculator_lambda_env_vars["OCCURRENCES_BUCKET_NAME"]
+    asid_lookup_bucket_name = calculator_lambda_env_vars["ASID_LOOKUP_BUCKET_NAME"]
+    telemetry_bucket_name = calculator_lambda_env_vars["TELEMETRY_BUCKET_NAME"]
+    metrics_bucket_name = calculator_lambda_env_vars["METRICS_BUCKET_NAME"]
     ccg = "My CCG"
     practice = "My First Surgery"
     create_occurrences_data(
@@ -96,37 +112,37 @@ def test_calculate_dashboard_metrics_from_telemetry(
         }]}
 
 
-@pytest.mark.skip(reason="Won't pass until all functionality implemented")
 def test_export_splunk_data(
-        test_client, lambda_environment_vars, s3, splunk):
+        test_client, exporter_lambda_env_vars, s3, splunk_response):
     ods_code = "A12345"
     old_asid = "1234"
     new_asid = "5678"
-    occurrences_bucket_name = lambda_environment_vars["OCCURRENCES_BUCKET_NAME"]
-    asid_lookup_bucket_name = lambda_environment_vars["ASID_LOOKUP_BUCKET_NAME"]
-    telemetry_bucket_name = lambda_environment_vars["TELEMETRY_BUCKET_NAME"]
+    occurrences_bucket_name = exporter_lambda_env_vars["OCCURRENCES_BUCKET_NAME"]
+    asid_lookup_bucket_name = exporter_lambda_env_vars["ASID_LOOKUP_BUCKET_NAME"]
+    telemetry_bucket_name = exporter_lambda_env_vars["TELEMETRY_BUCKET_NAME"]
+    telemetry_bucket = s3.create_bucket(Bucket=telemetry_bucket_name)
     ccg = "My CCG"
     practice = "My First Surgery"
     create_occurrences_data(
         occurrences_bucket_name, s3, ods_code, ccg, practice)
     create_asid_lookup_data(
         asid_lookup_bucket_name, s3, ods_code, old_asid, new_asid)
-    create_mock_splunk_data(splunk, old_asid)
+    create_mock_splunk_data(splunk_response)
 
     response = test_client.lambda_.invoke('splunk-data-exporter')
     assert response.payload == "ok"
 
-    pre_cutover_telemetry_obj = telemetry_bucket_name.Object(
+    pre_cutover_telemetry_obj = telemetry_bucket.Object(
         f"{old_asid}-telemetry.csv.gz").get()
-    pre_cutover_telemetry = pre_cutover_telemetry_obj['Body'].read().decode(
-        'utf-8')
-    assert json.loads(pre_cutover_telemetry) == SPINE_PRE_CUTOVER_DATA
+    pre_cutover_telemetry = pre_cutover_telemetry_obj['Body'].read()
+    unzipped_pre_cutover_telemetry = gzip.decompress(pre_cutover_telemetry)
+    assert unzipped_pre_cutover_telemetry == SPINE_PRE_CUTOVER_DATA
 
-    post_cutover_telemetry_obj = telemetry_bucket_name.Object(
+    post_cutover_telemetry_obj = telemetry_bucket.Object(
         f"{new_asid}-telemetry.csv.gz").get()
-    post_cutover_telemetry = post_cutover_telemetry_obj['Body'].read().decode(
-        'utf-8')
-    assert json.loads(post_cutover_telemetry) == SPINE_POST_CUTOVER_DATA
+    post_cutover_telemetry = post_cutover_telemetry_obj['Body'].read()
+    unzipped_post_cutover_telemetry = gzip.decompress(post_cutover_telemetry)
+    assert unzipped_post_cutover_telemetry == SPINE_POST_CUTOVER_DATA
 
 
 def create_occurrences_data(occurrences_bucket_name, s3, ods_code, ccg, practice):
@@ -188,10 +204,10 @@ def create_metrics_bucket(metrics_bucket_name, s3):
     return metrics_bucket
 
 
-def create_mock_splunk_data(splunk):
+def create_mock_splunk_data(splunk_response):
 
-    splunk.return_value = [
-        lambda: Mock(status=200, read=lambda: SPINE_BASELINE_DATA),
-        lambda: Mock(status=200, read=lambda: SPINE_PRE_CUTOVER_DATA),
-        lambda: Mock(status=200, read=lambda: SPINE_POST_CUTOVER_DATA),
+    splunk_response.side_effect = [
+        Mock(status=200, read=lambda: SPINE_BASELINE_DATA),
+        Mock(status=200, read=lambda: SPINE_PRE_CUTOVER_DATA),
+        Mock(status=200, read=lambda: SPINE_POST_CUTOVER_DATA),
     ]

--- a/metrics-calculator/tests/unit/test_app.py
+++ b/metrics-calculator/tests/unit/test_app.py
@@ -185,11 +185,7 @@ def test_calculate_dashboard_metrics_from_telemetry_includes_practice_details_fr
         lookup_asids_mock,
         engine_mock,
         upload_migrations_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     calculate_dashboard_metrics_from_telemetry({}, {})
@@ -350,12 +346,7 @@ def test_export_splunk_data_gets_asids_for_ods_code_in_occurrences_data(
         occurrences_mock,
         lookup_asids_mock,
         exporter_lambda_env_vars):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date.today()
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     export_splunk_data({}, {})
@@ -371,12 +362,7 @@ def test_export_splunk_data_gets_baseline_date_range(
         mock_defaults,
         occurrences_mock,
         calculate_baseline_date_range_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     export_splunk_data({}, {})
@@ -389,12 +375,7 @@ def test_export_splunk_data_gets_pre_cutover_date_range(
         mock_defaults,
         occurrences_mock,
         calculate_pre_cutover_date_range_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     export_splunk_data({}, {})
@@ -407,12 +388,7 @@ def test_export_splunk_data_gets_post_cutover_date_range(
         mock_defaults,
         occurrences_mock,
         calculate_post_cutover_date_range_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     export_splunk_data({}, {})
@@ -436,12 +412,7 @@ def test_export_splunk_data_gets_splunk_api_token(
         mock_defaults,
         occurrences_mock,
         get_splunk_api_token_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
 
     export_splunk_data({}, {})
@@ -456,12 +427,7 @@ def test_export_splunk_data_gets_splunk_api_token_once_regardless_of_number_of_m
         mock_defaults,
         occurrences_mock,
         get_splunk_api_token_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [
         migration_occurrence, migration_occurrence]
 
@@ -478,12 +444,7 @@ def test_export_splunk_data_queries_splunk_for_baseline_threshold(
         exporter_lambda_env_vars,
         get_splunk_api_token_mock,
         get_baseline_threshold_from_splunk_data_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
     old_asid = "12345"
     lookup_asids_mock.return_value = {
@@ -510,12 +471,7 @@ def test_export_splunk_data_queries_splunk_data_using_baseline_threshold(
         get_splunk_api_token_mock,
         get_baseline_threshold_from_splunk_data_mock,
         get_telemetry_from_splunk_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
     old_asid = "12345"
     new_asid = "09876"
@@ -549,12 +505,7 @@ def test_export_splunk_data_uploads_telemetry_to_s3(
         lookup_asids_mock,
         exporter_lambda_env_vars,
         get_telemetry_from_splunk_mock):
-    migration_occurrence = {
-        "ods_code": "A32323",
-        "ccg_name": "Test CCG",
-        "practice_name": "Test Surgery",
-        "date": date(2021, 7, 11)
-    }
+    migration_occurrence = aMigrationOccurrence()
     occurrences_mock.return_value = [migration_occurrence]
     old_asid = "12345"
     new_asid = "09876"
@@ -581,3 +532,12 @@ def test_export_splunk_data_uploads_telemetry_to_s3(
         new_telemetry_data,
         f"{new_asid}-telemetry.csv.gz"
     )
+
+
+def aMigrationOccurrence():
+    return {
+        "ods_code": "A32323",
+        "ccg_name": "Test CCG",
+        "practice_name": "Test Surgery",
+        "date": date(2021, 7, 11)
+    }

--- a/metrics-calculator/tests/unit/test_app.py
+++ b/metrics-calculator/tests/unit/test_app.py
@@ -130,7 +130,8 @@ def mock_defaults(
         occurrences_mock,
         lookup_asids_mock,
         get_baseline_threshold_from_splunk_data_mock,
-        get_telemetry_from_splunk_mock):
+        get_telemetry_from_splunk_mock,
+        upload_telemetry_mock):
     pass
 
 

--- a/metrics-calculator/tests/unit/test_app.py
+++ b/metrics-calculator/tests/unit/test_app.py
@@ -429,8 +429,10 @@ def test_export_splunk_data_queries_splunk_for_baseline_threshold(
 
     export_splunk_data({}, {})
 
+    token = "this-is-a-token"
     get_baseline_threshold_from_splunk_data_mock.assert_called_once_with(
         exporter_lambda_env_vars["SPLUNK_HOST"],
+        token,
         old_asid,
         calculate_baseline_date_range_mock.return_value)
 
@@ -462,16 +464,19 @@ def test_export_splunk_data_queries_splunk_data_using_baseline_threshold(
 
     export_splunk_data({}, {})
 
+    token = "this-is-a-token"
     get_telemetry_from_splunk_mock.assert_any_call(
         exporter_lambda_env_vars["SPLUNK_HOST"],
+        token,
         old_asid,
-        baseline_threshold,
-        calculate_pre_cutover_date_range_mock.return_value)
+        calculate_pre_cutover_date_range_mock.return_value,
+        baseline_threshold)
     get_telemetry_from_splunk_mock.assert_any_call(
         exporter_lambda_env_vars["SPLUNK_HOST"],
+        token,
         new_asid,
-        baseline_threshold,
-        calculate_post_cutover_date_range_mock.return_value)
+        calculate_post_cutover_date_range_mock.return_value,
+        baseline_threshold)
 
 
 def test_export_splunk_data_uploads_telemetry_to_s3(

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -94,14 +94,15 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
     threshold = "4537.33933970307"
-
-    splunk_response.return_value = Mock(read=lambda: b"""_time",count,avgmin2std
-"2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
+    expected_telemetry = b"""_time",count,avgmin2std
+"2021-09-06T00:00:00.000+0000",2,"4537.33933970307"""
+    splunk_response.return_value = Mock(
+        read=lambda: expected_telemetry, status=200)
 
     telemetry = get_telemetry_from_splunk(
         "", anAsid(), aDateRange(), threshold)
 
-    assert telemetry == splunk_response.return_value
+    assert telemetry == expected_telemetry
 
 
 def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response):

--- a/metrics-calculator/tests/unit/test_get_data_from_splunk.py
+++ b/metrics-calculator/tests/unit/test_get_data_from_splunk.py
@@ -36,7 +36,7 @@ def test_get_baseline_threshold_from_splunk_data_extracts_threshold_from_splunk_
 "2021-09-06T00:00:00.000+0000",2,"4537.33933970307""", status=200)
 
     baseline_threshold = get_baseline_threshold_from_splunk_data(
-        "", anAsid(), aDateRange())
+        "", anApiToken(), anAsid(), aDateRange())
 
     assert baseline_threshold == "4537.33933970307"
 
@@ -46,14 +46,16 @@ def test_get_baseline_threshold_from_splunk_data_handles_no_results(splunk_respo
 "2021-09-06T00:00:00.000+0000",0,""0""", status=200)
 
     with pytest.raises(ValueError, match="Threshold is not a positive value"):
-        get_baseline_threshold_from_splunk_data("", anAsid(), aDateRange())
+        get_baseline_threshold_from_splunk_data(
+            "", anApiToken(), anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_http_response_failure(splunk_response):
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_baseline_threshold_from_splunk_data("", anAsid(), aDateRange())
+        get_baseline_threshold_from_splunk_data(
+            "", anApiToken(), anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_response):
@@ -62,16 +64,17 @@ def test_get_baseline_threshold_from_splunk_data_handles_parse_failure(splunk_re
 
     with pytest.raises(SplunkParseError):
         get_baseline_threshold_from_splunk_data(
-            "", anAsid(), aDateRange())
+            "", anApiToken(), anAsid(), aDateRange())
 
 
 def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_request):
     asid = anAsid()
     baseline_date_range = aDateRange()
     splunk_host = "test-splunk"
+    token = anApiToken()
 
     get_baseline_threshold_from_splunk_data(
-        splunk_host, asid, baseline_date_range)
+        splunk_host, token, asid, baseline_date_range)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -87,9 +90,10 @@ def test_get_baseline_threshold_from_splunk_data_makes_correct_request(splunk_re
 | eval avgmin2std=average-(stdd*2)
 | fields - stdd"""
     }
+    expected_headers = {"Authorization": f"Bearer {token}"}
     splunk_request["connection"].assert_called_once_with(splunk_host)
     splunk_request["request"].assert_called_once_with(
-        "POST", "/search/jobs/export", expected_request_body)
+        "POST", "/search/jobs/export", expected_request_body, expected_headers)
 
 
 def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
@@ -100,7 +104,7 @@ def test_get_telemetry_from_splunk_get_cutover_telemetry(splunk_response):
         read=lambda: expected_telemetry, status=200)
 
     telemetry = get_telemetry_from_splunk(
-        "", anAsid(), aDateRange(), threshold)
+        "", anApiToken(), anAsid(), aDateRange(), threshold)
 
     assert telemetry == expected_telemetry
 
@@ -111,16 +115,18 @@ def test_get_telemetry_from_splunk_handles_http_response_failure(splunk_response
     splunk_response.return_value = Mock(status=404)
 
     with pytest.raises(SplunkQueryError, match="Splunk request returned a 404 code"):
-        get_telemetry_from_splunk("", anAsid(), aDateRange(), threshold)
+        get_telemetry_from_splunk(
+            "", anApiToken(), anAsid(), aDateRange(), threshold)
 
 
-def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
+def test_get_telemetry_from_splunk_makes_correct_request(splunk_request):
     asid = anAsid()
     date_range = aDateRange()
     threshold = "4537.33933970307"
     splunk_host = "test-splunk"
+    token = anApiToken()
 
-    get_telemetry_from_splunk(splunk_host, asid, date_range, threshold)
+    get_telemetry_from_splunk(splunk_host, token, asid, date_range, threshold)
 
     expected_request_body = {
         "output_mode": "csv",
@@ -134,9 +140,10 @@ def test_get_telemetry_from_splunk_has_correct_request_body(splunk_request):
 | eval avgmin2std={threshold}
 | fields - day_of_week"""
     }
+    expected_headers = {"Authorization": f"Bearer {token}"}
     splunk_request["connection"].assert_called_once_with(splunk_host)
     splunk_request["request"].assert_called_once_with(
-        "POST", "/search/jobs/export", expected_request_body)
+        "POST", "/search/jobs/export", expected_request_body, expected_headers)
 
 
 def anAsid():
@@ -144,5 +151,11 @@ def anAsid():
 
 
 def aDateRange():
-    return {"start_date": date(
-        2021, 4, 6), "end_date": date(2021, 6, 28)}
+    return {
+        "start_date": date(2021, 4, 6),
+        "end_date": date(2021, 6, 28)
+    }
+
+
+def anApiToken():
+    return "this-is-a-token"


### PR DESCRIPTION
* Provision a Splunk API access token parameter, with a dummy value.
* Update the splunk data exporter lambda to read the parameter value and use when authenticating with Splunk.